### PR TITLE
add development docker-compose configuration, closes #15

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,6 @@
+version: "3"
+services:
+  app:
+    container_name: wafflemap
+    restart: no
+    entrypoint: ["echo", "the wafflemap service is disabled during development"]


### PR DESCRIPTION
adds a modifier for the standard docker-compose.yml

Executing `docker compose -f docker-compose.yml -f docker-compose.dev.yml up`
will now disable the app service, allowing developers to run the app outside docker.

closes #15 