### PR TITLE
fix eslint ci script, closes #27

### DIFF
--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -22,4 +22,4 @@ jobs:
         run: |
           cd frontend
           npm ci
-          npx eslint src/**
+          npx eslint --ext .js,.jsx,.ts,.tsx src/


### PR DESCRIPTION
Only specifies source directory that ESLint should recursively search.
Additionally makes it so ESLint only scans for js(x) and ts(x) files.

closes #27 