### PR TITLE
Remove db-init script output buffering

### DIFF
--- a/docker/postgres/init.sh
+++ b/docker/postgres/init.sh
@@ -9,4 +9,4 @@ until psql -v ON_ERROR_STOP=1 -U "${WM_POSTGRES_USER}" -d "${WM_POSTGRES_DB}" -c
 done
 unset PGPASSWORD
 
-python3 /wafflemap_db_init/download_insert_osm_data.py
+python3 -u /wafflemap_db_init/download_insert_osm_data.py


### PR DESCRIPTION
This fixes the output buffering issue.

closes #34 